### PR TITLE
(SIMP-6103) Replace OBE validate_umask() with Simplib::Umask

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -70,7 +70,7 @@ variables:
 #-----------------------------------------------------------------------
 
 .pup_4: &pup_4
-  image: 'ruby:2.4'
+  image: 'ruby:2.1'
   variables:
     PUPPET_VERSION: '~> 4.0'
     MATRIX_RUBY_VERSION: '2.1'

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,7 @@ addons:
 
 before_install:
   - rm -f Gemfile.lock
+  - gem install -v '~> 1.17' bundler
 
 global:
   - STRICT_VARIABLES=yes

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,14 @@
+* Tue Feb 12 2019 Liz Nemsick <lnemsick.simp@gmail.com> - 4.1.1-0
+- Fixed bug in which the xinetd::disabled parameter would only
+  be included in xinetd.conf if the xinetd::no_access parameter
+  was not empty.
+- Use Simplib::Umask data type in lieu of validate_umask(),
+  a deprecated simplib Puppet 3 function.
+- Use simplib::validate_net_list() in lieu of validate_net_list(),
+  a deprecated simplib Puppet 3 function.
+- Use simplib::nets2cidr() in lieu of nets2cidr(),
+  a deprecated simplib Puppet 3 function.
+
 * Fri Aug 24 2018 Nick Miller <nick.miller@onyxpoint.com> - 4.1.0-0
 - Add support for Puppet 5 and OEL
 - Added $package_ensure parameter

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -6,13 +6,13 @@
 #
 # Explanations of the options can be found in the xinetd.conf(5) man page.
 #
-# @author Trevor Vaughan <tvaughan@onyxpoint.com>
+# @author https://github.com/simp/pupmod-simp-xinetd/graphs/contributors
 #
 class xinetd (
   String                           $log_type       = 'SYSLOG authpriv',
   Optional[String]                 $x_bind         = undef,
   Optional[Xinetd::UnlimitedInt]   $per_source     = undef,
-  Optional[String]                 $x_umask        = undef,
+  Optional[Simplib::Umask]         $x_umask        = undef,
   Array[Xinetd::SuccessLogOption]  $log_on_success = ['HOST','PID','DURATION','TRAFFIC'],
   Array[Xinetd::FailureLogOption]  $log_on_failure = ['HOST'],
   Array[String]                    $trusted_nets   = lookup('simp_options::trusted_nets', { 'default_value' => ['127.0.0.1', '::1'] }),
@@ -34,9 +34,10 @@ class xinetd (
   #TODO Fix the inconsistent use of strings versus arrays.  Some of these
   # config items are strings that contain a space-separated list of items.
   xinetd::validate_log_type($log_type)
-  if $x_bind  { validate_net_list($x_bind) }
-  if $x_umask { validate_umask($x_umask) }
-  if $no_access { validate_net_list($no_access) }
+  if $x_bind  { simplib::validate_net_list($x_bind) }
+  if $no_access { simplib::validate_net_list($no_access) }
+
+  $_only_from = simplib::nets2cidr($trusted_nets)
 
   file { '/etc/xinetd.conf':
     owner   => 'root',

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -6,7 +6,7 @@
 # Items prefixed with 'x_' were reserved words in ERB.
 # * xinetd/xinetd.service.erb
 #
-# @author Trevor Vaughan <tvaughan@onyxpoint.com>
+# @author https://github.com/simp/pupmod-simp-xinetd/graphs/contributors
 #
 define xinetd::service (
   String                            $server,
@@ -18,7 +18,7 @@ define xinetd::service (
   Optional[String]                  $libwrap_name   = undef,
   Optional[String]                  $libwrap        = undef,
   String                            $user           = 'root',
-  String                            $x_umask        = '027',
+  Simplib::Umask                    $x_umask        = '027',
   String                            $log_type       = 'SYSLOG authpriv',
   Array[Xinetd::SuccessLogOption]   $log_on_success = ['HOST','PID','DURATION','TRAFFIC'],
   Array[Xinetd::FailureLogOption]   $log_on_failure = ['HOST'],
@@ -58,10 +58,10 @@ define xinetd::service (
   Boolean                           $firewall       = simplib::lookup('simp_options::firewall', { 'default_value' => false }),
   Boolean                           $tcpwrappers    = simplib::lookup('simp_options::tcpwrappers', { 'default_value' => false })
 ) {
-  validate_umask($x_umask)
   xinetd::validate_log_type($log_type)
-  if ($redirect_ip and $redirect_port) { validate_net_list("${redirect_ip}:${redirect_port}") }
-  if $x_bind                           { validate_net_list($x_bind) }
+  if ($redirect_ip and $redirect_port) { simplib::validate_net_list("${redirect_ip}:${redirect_port}") }
+  if $x_bind                           { simplib::validate_net_list($x_bind) }
+  $_only_from = simplib::nets2cidr($trusted_nets)
 
   include '::xinetd'
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-xinetd",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "author": "SIMP Team",
   "summary": "Manages xinetd",
   "license": "Apache-2.0",
@@ -22,7 +22,7 @@
     },
     {
       "name": "simp/simplib",
-      "version_requirement": ">= 3.1.0 < 4.0.0"
+      "version_requirement": ">= 3.7.0 < 4.0.0"
     },
     {
       "name": "simp/tcpwrappers",

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -59,7 +59,7 @@ EOM
             :per_source     => 'UNLIMITED',
             :x_umask        => '0700',
             :trusted_nets   => ['1.2.3.0/24', '10.0.2.5', '2001:db8:a::/64'],
-	    :no_access      => ['1.2.3.4', '2.3.4.5'],
+            :no_access      => ['1.2.3.4', '2.3.4.5'],
             :passenv        => 'SOMEENVVAR1 SOMENVVAR2',
             :disabled       => ['some_disabled_id1', 'some_disabled_id2'],
             :disable        => 'yes',

--- a/templates/xinetd.conf.erb
+++ b/templates/xinetd.conf.erb
@@ -1,60 +1,50 @@
 defaults
 {
-<% if !@log_type.nil? then -%>
   log_type       = <%= @log_type %>
-<% end -%>
-<% if !@x_bind.nil? then -%>
+<% unless @x_bind.nil? -%>
   bind           = <%= @x_bind %>
 <% end -%>
-<% if !@per_source.nil? then -%>
+<% unless @per_source.nil? -%>
   per_source     = <%= @per_source %>
 <% end -%>
-<% if !@x_umask.nil? then -%>
+<% unless @x_umask.nil? -%>
   umask          = <%= @x_umask %>
 <% end -%>
-<% if !@log_on_success.nil? then -%>
+<% unless @log_on_success.empty? -%>
   log_on_success = <%= @log_on_success.join(' ') %>
 <% end -%>
-<% if !@log_on_failure.nil? then -%>
+<% unless @log_on_failure.empty? -%>
   log_on_failure = <%= @log_on_failure.join(' ') %>
 <% end -%>
-<% if !@trusted_nets.empty? then -%>
-  only_from      = <%=scope.function_nets2cidr(@trusted_nets).join(' ') %>
+<% unless @_only_from.empty? -%>
+  only_from      = <%= @_only_from.join(' ') %>
 <% end -%>
-<% if !@no_access.nil? and !@no_access.empty? then -%>
+<% if !@no_access.nil? and !@no_access.empty? -%>
   no_access      = <%= @no_access.join(' ') %>
 <% end -%>
-<% if !@passenv.nil? then -%>
+<% unless @passenv.nil? -%>
   passenv        = <%= @passenv %>
 <% end -%>
-<% if !@instances.nil? then -%>
   instances      = <%= @instances %>
-<% end -%>
-<% if !@disabled.nil?  and !@no_access.empty? then -%>
+<% if !@disabled.nil? and !@disabled.empty? -%>
   disabled       = <%= @disabled.join(' ') %>
 <% end -%>
-<% if !@disable.nil? then -%>
+<% unless @disable.nil? -%>
   disable        = <%= @disable %>
 <% end -%>
-<% if !@enabled.nil? and !@enabled.empty? then -%>
+<% if !@enabled.nil? and !@enabled.empty? -%>
   enabled        = <%= @enabled.join(' ') %>
 <% end -%>
-<% if !@banner.nil? then -%>
   banner         = <%= @banner %>
-<% end -%>
-<% if !@banner_success.nil? then -%>
+<% unless @banner_success.nil? -%>
   banner_success = <%= @banner_success %>
 <% end -%>
-<% if !@banner_fail.nil? then -%>
+<% unless @banner_fail.nil? -%>
   banner_fail    = <%= @banner_fail %>
 <% end -%>
-<% if !@groups.nil? then -%>
   groups         = <%= @groups %>
-<% end -%>
-<% if !@cps.nil? then -%>
   cps            = <%= @cps.join(' ') %>
-<% end -%>
-<% if !@max_load.nil? then -%>
+<% unless @max_load.nil? -%>
   max_load       = <%= @max_load %>
 <% end -%>
 }

--- a/templates/xinetd.service.erb
+++ b/templates/xinetd.service.erb
@@ -6,114 +6,118 @@ service <%= @name %>
     wait = <%= @x_wait %>
     disable = <%= @disable %>
     log_type = <%= @log_type %>
+<% unless @log_on_success.empty? -%>
     log_on_success = <%= @log_on_success.join(' ') %>
+<% end -%>
+<% unless @log_on_failure.empty? -%>
     log_on_failure = <%= @log_on_failure.join(' ') %>
+<% end -%>
     port = <%= @port %>
     umask = <%= @x_umask %>
-<% if ! @x_id.nil? then -%>
+<% unless @x_id.nil? -%>
     id = <%= @x_id %>
 <% end -%>
-<% if ! @x_type.nil? then -%>
+<% unless @x_type.nil? -%>
     type = <%= @x_type %>
 <% end -%>
 <% if ! @flags.nil? and ! @flags.empty? then -%>
     flags = <%= @flags.join(' ') %>
 <% end -%>
-<% if ! @protocol.nil? then -%>
+<% unless @protocol.empty? -%>
     protocol = <%= @protocol %>
 <% end -%>
-<% if ! @group.nil? then -%>
+<% unless @group.nil? -%>
     group = <%= @group %>
 <% end -%>
-<% if ! @nice.nil? then -%>
+<% unless @nice.nil? -%>
     nice = <%= @nice %>
 <% end -%>
-<% if ! @server_args.nil? then -%>
+<% unless @server_args.nil? -%>
     server_args = <%= @server_args %>
 <% end -%>
-<% if ! @libwrap.nil? then -%>
+<% unless @libwrap.nil? -%>
     libwrap = <%= @libwrap %>
 <% end -%>
-<% if ! @trusted_nets.empty? then -%>
-    only_from = <%= scope.function_nets2cidr(@trusted_nets).join(' ') %>
+<% unless @_only_from.empty? -%>
+    only_from = <%= @_only_from.join(' ') %>
 <% end -%>
-<% if ! @instances.nil? then -%>
+<% unless @instances.nil? -%>
     instances = <%= @instances %>
 <% end -%>
-<% if ! @access_times.nil? then -%>
+<% unless @access_times.nil? -%>
     access_times = <%= @access_times %>
 <% end -%>
-<% if ! @rpc_version.nil? then -%>
+<% unless @rpc_version.nil? -%>
     rpc_version = <%= @rpc_version %>
 <% end -%>
-<% if ! @rpc_number.nil? then -%>
+<% unless @rpc_number.nil? -%>
     rpc_number = <%= @rpc_number %>
 <% end -%>
-<% if ! @env.nil? then -%>
+<% unless @env.nil? -%>
     env = <%= @env %>
 <% end -%>
-<% if ! @passenv.nil? then -%>
+<% unless @passenv.nil? -%>
     passenv = <%= @passenv %>
 <% end -%>
-<% if ! @redirect_ip.nil? then -%>
+<% unless @redirect_ip.nil? -%>
     redirect = <%= @redirect_ip -%>
-<%  if ! @redirect_port.nil? then -%>
+<%  unless @redirect_port.nil? -%>
  <%=  @redirect_port -%>
 <%  end -%>
 <% end %>
-<% if ! @x_bind.nil? then -%>
+<% unless @x_bind.nil? -%>
     bind = <%= @x_bind %>
 <% end -%>
-<% if ! @banner.nil? then -%>
+<% unless @banner.nil? -%>
     banner = <%= @banner %>
 <% end -%>
-<% if ! @banner_success.nil? then -%>
+<% unless @banner_success.nil? -%>
     banner_success = <%= @banner_success %>
 <% end -%>
-<% if ! @banner_fail.nil? then -%>
+<% unless @banner_fail.nil? -%>
     banner_fail = <%= @banner_fail %>
 <% end -%>
-<% if ! @per_source.nil? then -%>
+<% unless @per_source.nil? -%>
     per_source = <%= @per_source %>
 <% end -%>
-<% if ! @cps.nil? then -%>
+<% unless @cps.nil? -%>
     cps = <%= @cps.join(' ') %>
 <% end -%>
-<% if ! @max_load.nil? then -%>
+<% unless @max_load.nil? -%>
     max_load = <%= @max_load %>
 <% end -%>
-<% if ! @groups.nil? then -%>
+<% unless @groups.nil? -%>
     groups = <%= @groups %>
 <% end -%>
-<% if ! @mdns.nil? then -%>
+<% unless @mdns.nil? -%>
     mdns = <%= @mdns %>
 <% end -%>
 <% if ! @enabled.nil? and ! @enabled.empty? then -%>
     enabled = <%= @enabled.join(' ') %>
 <% end -%>
-<% if ! @rlimit_as.nil? then -%>
+<% unless @rlimit_as.nil? -%>
     rlimit_as = <%= @rlimit_as %>
 <% end -%>
-<% if ! @rlimit_cpu.nil? then -%>
+<% unless @rlimit_cpu.nil? -%>
     rlimit_cpu = <%= @rlimit_cpu %>
 <% end -%>
-<% if ! @rlimit_data.nil? then -%>
+<% unless @rlimit_data.nil? -%>
     rlimit_data = <%= @rlimit_data %>
 <% end -%>
-<% if ! @rlimit_rss.nil? then -%>
+<% unless @rlimit_rss.nil? -%>
     rlimit_rss = <%= @rlimit_rss %>
 <% end -%>
-<% if ! @rlimit_stack.nil? then -%>
+<% unless @rlimit_stack.nil? -%>
     rlimit_stack = <%= @rlimit_stack %>
 <% end -%>
-<% if ! @deny_time.nil? then -%>
+<% unless @deny_time.nil? -%>
     deny_time = <%= @deny_time %>
 <% end -%>
 }
 
-<% if ! @include.nil? then -%>
+<% unless @include.nil? -%>
 include <%= @include %>
 <% end -%>
-<% if ! @includedir.nil? then -%>
+<% unless @includedir.nil? -%>
 includedir <%= @includedir %>
 <% end -%>


### PR DESCRIPTION
- Fixed bug in which the xinetd::disabled parameter would only
  be included in xinetd.conf if the xinetd::no_access parameter
  was not empty.
- Use Simplib::Umask data type in lieu of validate_umask(),
  a deprecated simplib Puppet 3 function.
- Use simplib::validate_net_list() in lieu of validate_net_list(),
  a deprecated simplib Puppet 3 function.
- Use simplib::nets2cidr() in lieu of nets2cidr(),
  a deprecated simplib Puppet 3 function.

SIMP-6103 #comment pupmod-simp-xinetd