### PR TITLE
(SIMP-6213) Use latest concat in tests

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,11 +1,7 @@
 ---
 fixtures:
   repositories:
-    concat:
-      # master is beyond 4.1.1, but has breaking changes to
-      # how fragments are ordered (MODULES-6625)
-      repo: https://github.com/simp/puppetlabs-concat
-      ref: 4.1.1
+    concat: https://github.com/simp/puppetlabs-concat
     iptables: https://github.com/simp/pupmod-simp-iptables
     simplib: https://github.com/simp/pupmod-simp-simplib
     stdlib: https://github.com/simp/puppetlabs-stdlib

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -8,6 +8,7 @@
   a deprecated simplib Puppet 3 function.
 - Use simplib::nets2cidr() in lieu of nets2cidr(),
   a deprecated simplib Puppet 3 function.
+- Expanded the upper limits of the stdlib Puppet module version
 
 * Fri Aug 24 2018 Nick Miller <nick.miller@onyxpoint.com> - 4.1.0-0
 - Add support for Puppet 5 and OEL

--- a/metadata.json
+++ b/metadata.json
@@ -14,7 +14,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.13.1 < 5.0.0"
+      "version_requirement": ">= 4.13.1 < 6.0.0"
     },
     {
       "name": "simp/iptables",


### PR DESCRIPTION
- Test with latest concat Puppet module instead of 4.1.1
- Expanded the upper limits of the stdlib Puppet module version

SIMP-6213 #comment pupmod-simp-xinetd