### PR TITLE
(SIMP-6235) Allow users to purge xinetd services

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -12,7 +12,6 @@
 # PE 2019.0     6.0      2.5.1  2019-08-31^^^
 #
 # *** = Modules created for SIMP 6.3+ are not required to support Puppet < 5.5
-# ^^^ = SIMP doesn't support 6 yet; tests are info-only and allowed to fail
 ---
 stages:
   - 'sanity'
@@ -92,7 +91,6 @@ variables:
     MATRIX_RUBY_VERSION: '2.4'
 
 .pup_6: &pup_6
-  allow_failure: true
   image: 'ruby:2.5'
   variables:
     PUPPET_VERSION: '~> 6.0'

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,6 @@
 # PE 2019.0     6.0      2.5.1  2019-08-31^^^
 #
 # *** = Modules created for SIMP 6.3+ are not required to support Puppet < 5.5
-# ^^^ = SIMP doesn't support 6 yet; tests are info-only and allowed to fail
 
 ---
 language: ruby
@@ -44,9 +43,6 @@ global:
   - STRICT_VARIABLES=yes
 
 jobs:
-  allow_failures:
-    - name: 'Latest Puppet 6.x (allowed to fail)'
-
   include:
     - stage: check
       name: 'Syntax, style, and validation checks'
@@ -91,7 +87,7 @@ jobs:
         - bundle exec rake spec
 
     - stage: spec
-      name: 'Latest Puppet 6.x (allowed to fail)'
+      name: 'Latest Puppet 6.x'
       rvm: 2.5.1
       env: PUPPET_VERSION="~> 6.0"
       script:

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Thu Mar 07 2019 Trevor Vaughan <tvaughan@onyxpoint.com> - 4.1.1-0
+- Allow users to purge unmanaged xinetd services
+- Add support for Puppet 6
+
 * Tue Feb 12 2019 Liz Nemsick <lnemsick.simp@gmail.com> - 4.1.1-0
 - Fixed bug in which the xinetd::disabled parameter would only
   be included in xinetd.conf if the xinetd::no_access parameter

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -6,29 +6,56 @@
 #
 # Explanations of the options can be found in the xinetd.conf(5) man page.
 #
+# @param log_type
+# @param x_bind
+# @param per_source
+# @param x_umask
+# @param log_on_success
+# @param log_on_failure
+# @param trusted_nets
+# @param no_access
+# @param passenv
+# @param instances
+# @param disabled
+# @param disable
+# @param enabled
+# @param banner
+# @param banner_success
+# @param banner_fail
+# @param groups
+# @param cps
+# @param max_load
+#
+# @param purge
+#   Purge all unmanaged services
+#
+# @param package_ensure
+#   The ``package`` resource ensure to apply to all included package resources
+#
 # @author https://github.com/simp/pupmod-simp-xinetd/graphs/contributors
 #
 class xinetd (
-  String                           $log_type       = 'SYSLOG authpriv',
-  Optional[String]                 $x_bind         = undef,
-  Optional[Xinetd::UnlimitedInt]   $per_source     = undef,
-  Optional[Simplib::Umask]         $x_umask        = undef,
-  Array[Xinetd::SuccessLogOption]  $log_on_success = ['HOST','PID','DURATION','TRAFFIC'],
-  Array[Xinetd::FailureLogOption]  $log_on_failure = ['HOST'],
-  Array[String]                    $trusted_nets   = lookup('simp_options::trusted_nets', { 'default_value' => ['127.0.0.1', '::1'] }),
-  Optional[Array[String]]          $no_access      = undef,
-  Optional[String]                 $passenv        = undef,
-  Xinetd::UnlimitedInt             $instances      = '60',
-  Optional[Array[String]]          $disabled       = undef,
-  Optional[Enum['yes','no']]       $disable        = undef,
-  Optional[Array[String]]          $enabled        = undef,
-  Stdlib::Absolutepath             $banner         = '/etc/issue.net',
-  Optional[Stdlib::Absolutepath]   $banner_success = undef,
-  Optional[Stdlib::Absolutepath]   $banner_fail    = undef,
-  Enum['yes','no']                 $groups         = 'no',
-  Tuple[Integer,Integer]           $cps            = [25,30],
-  Optional[Float]                  $max_load       = undef,
-  String                           $package_ensure = simplib::lookup('simp_options::package_ensure', { 'default_value' => 'installed' }),
+  String[1]                       $log_type       = 'SYSLOG authpriv',
+  Optional[String[1]]             $x_bind         = undef,
+  Optional[Xinetd::UnlimitedInt]  $per_source     = undef,
+  Optional[Simplib::Umask]        $x_umask        = undef,
+  Array[Xinetd::SuccessLogOption] $log_on_success = ['HOST','PID','DURATION','TRAFFIC'],
+  Array[Xinetd::FailureLogOption] $log_on_failure = ['HOST'],
+  Simplib::Netlist                $trusted_nets   = lookup('simp_options::trusted_nets', { 'default_value' => ['127.0.0.1', '::1'] }),
+  Optional[Array[String[1]]]      $no_access      = undef,
+  Optional[String[1]]             $passenv        = undef,
+  Xinetd::UnlimitedInt            $instances      = '60',
+  Optional[Array[String[1]]]      $disabled       = undef,
+  Optional[Enum['yes','no']]      $disable        = undef,
+  Optional[Array[String[1]]]      $enabled        = undef,
+  Stdlib::Absolutepath            $banner         = '/etc/issue.net',
+  Optional[Stdlib::Absolutepath]  $banner_success = undef,
+  Optional[Stdlib::Absolutepath]  $banner_fail    = undef,
+  Enum['yes','no']                $groups         = 'no',
+  Tuple[Integer[1],Integer[1]]    $cps            = [25,30],
+  Optional[Float[0]]              $max_load       = undef,
+  Boolean                         $purge          = false,
+  String[1]                       $package_ensure = simplib::lookup('simp_options::package_ensure', { 'default_value' => 'installed' }),
 ) {
 
   #TODO Fix the inconsistent use of strings versus arrays.  Some of these
@@ -54,6 +81,7 @@ class xinetd (
     group   => 'root',
     mode    => '0640',
     recurse => true,
+    purge   => $purge,
     require => Package['xinetd']
   }
 

--- a/metadata.json
+++ b/metadata.json
@@ -55,7 +55,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 4.7.0 < 6.0.0"
+      "version_requirement": ">= 4.7.0 < 7.0.0"
     }
   ]
 }

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -8,6 +8,7 @@ shared_examples_for 'a xinetd class' do
       'owner'   => 'root',
       'group'   => 'root',
       'mode'    => '0640',
+      'purge'   => 'false',
       'recurse' => 'true'
     })
   end


### PR DESCRIPTION
This update allows users to purge unknown xinetd services to provide a
capability similar to that of svckill but for the xinetd subsystem.

SIMP-6235 #close