### PR TITLE
(SIMP-7855) Update GLCI to test puppet 5.5.20

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -8,9 +8,10 @@ fixtures:
     concat: https://github.com/simp/puppetlabs-concat
     firewalld:
       repo: https://github.com/simp/pupmod-voxpupuli-firewalld
-      ref: v4.1.0
+      ref: v4.3.0
     iptables: https://github.com/simp/pupmod-simp-iptables
     simp_options: https://github.com/simp/pupmod-simp-simp_options
+    simp_firewalld: https://github.com/simp/pupmod-simp-simp_firewalld
     simplib: https://github.com/simp/pupmod-simp-simplib
     stdlib: https://github.com/simp/puppetlabs-stdlib
     tcpwrappers: https://github.com/simp/pupmod-simp-tcpwrappers

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -194,10 +194,10 @@ variables:
     BEAKER_PUPPET_COLLECTION: 'puppet5'
     MATRIX_RUBY_VERSION: '2.4'
 
-.pup_5_5_17: &pup_5_5_17
+.pup_5_5_20: &pup_5_5_20
   image: 'ruby:2.4'
   variables:
-    PUPPET_VERSION: '5.5.17'
+    PUPPET_VERSION: '5.5.20'
     BEAKER_PUPPET_COLLECTION: 'puppet5'
     MATRIX_RUBY_VERSION: '2.4'
 
@@ -283,14 +283,16 @@ pup6-lint:
 pup5-unit:
   <<: *pup_5
   <<: *unit_tests
+  <<: *with_SIMP_SPEC_MATRIX_LEVEL_2
 
-pup5.5.17-unit:
-  <<: *pup_5_5_17
+pup5.5.20-unit:
+  <<: *pup_5_5_20
   <<: *unit_tests
 
 pup6-unit:
   <<: *pup_6
   <<: *unit_tests
+  <<: *with_SIMP_SPEC_MATRIX_LEVEL_2
 
 pup6.16.0-unit:
   <<: *pup_6_16_0
@@ -306,20 +308,20 @@ pup6.16.0-unit:
 # Repo-specific content
 # ==============================================================================
 
-pup5.5.17:
-  <<: *pup_5_5_17
+pup5.5.20:
+  <<: *pup_5_5_20
   <<: *acceptance_base
   script:
     - 'bundle exec rake beaker:suites[default]'
 
-pup5.5.17-oel:
-  <<: *pup_5_5_17
+pup5.5.20-oel:
+  <<: *pup_5_5_20
   <<: *acceptance_base
   script:
     - 'bundle exec rake beaker:suites[default,oel]'
 
-pup5.5.17-fips:
-  <<: *pup_5_5_17
+pup5.5.20-fips:
+  <<: *pup_5_5_20
   <<: *acceptance_base
   script:
     - 'BEAKER_fips=yes bundle exec rake beaker:suites[default,default]'

--- a/.pmtignore
+++ b/.pmtignore
@@ -8,6 +8,7 @@
 .yardoc
 dist/
 pkg/
+spec/defines/
 spec/fixtures/
 spec/acceptance/
 spec/rp_env/
@@ -21,3 +22,4 @@ vendor/
 junit/
 log/
 doc/
+tests/

--- a/.puppet-lint.rc
+++ b/.puppet-lint.rc
@@ -4,3 +4,6 @@
 --no-140chars-check
 --no-trailing_comma-check
 --no-empty_string_assignment-check
+# This is here because the code can't handle lookups in parameters and SIMP
+# modules have a LOT of those
+--no-parameter_order-check


### PR DESCRIPTION
In addition to the puppet update, this patch adds simp_firewalld to the
fixtures in order to fix acceptance test dependencies.

CI: MATRIX LEVEL 1

SIMP-8318 #close
[SIMP-7855] #comment Updated pupmod-simp-xinetd
[SIMP-7971] #close #comment Added simp_firewalld to .fixtures.yml
[SIMP-8237] #comment Added `--no-parameter_order_check` to pupmod-simp-xinetd

[SIMP-7855]: https://simp-project.atlassian.net/browse/SIMP-7855

[SIMP-7971]: https://simp-project.atlassian.net/browse/SIMP-7971
[SIMP-8237]: https://simp-project.atlassian.net/browse/SIMP-8237