### PR TITLE
RFC:  The module must not manage xinetd files and services when  $package_ensure == 'absent'.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -66,6 +66,7 @@ class xinetd (
 
   $_only_from = simplib::nets2cidr($trusted_nets)
 
+### The module should not be managing the files when $package_ensure == 'absent'.
   file { '/etc/xinetd.conf':
     owner   => 'root',
     group   => 'root',
@@ -75,6 +76,7 @@ class xinetd (
     require => Package['xinetd']
   }
 
+### The module should not be managing xinetd files when $package_ensure == 'absent'.
   file { '/etc/xinetd.d':
     ensure  => 'directory',
     owner   => 'root',
@@ -89,6 +91,7 @@ class xinetd (
     ensure => $package_ensure
   }
 
+### The module should not be managing the services when $package_ensure == 'absent'.
   service { 'xinetd':
     ensure    => 'running',
     enable    => true,


### PR DESCRIPTION
When uninstalling the xinetd package, this module attempts to manage /etc/xined.conf, /etc/xinetd.d/ files and attempts (in vain) to start the xinetd service.

I couldn't figure out how to open a new issue so I've commented the init.pp file appropriately and am asking for comments on this issue.

I have about 50 servers that need xinetd with the exception of one.  In the node's YAML file, I've put "xinetd::package_ensure: absent" and the module fails because it's trying to manage the xinetd files when it shouldn't.  

Yes, I realize I could write a conditional check NOT to include ::xinetd::service but then I'd eventually have spaghetti code trying to work around the module's bug.  I'm kind of a purist and believe that the module should do no harm even when it's called and the packages don't need to be installed.