### PR TITLE
Add RockyLinux 8 support

### DIFF
--- a/.github/workflows/pr_tests.yml
+++ b/.github/workflows/pr_tests.yml
@@ -109,14 +109,16 @@ jobs:
     strategy:
       matrix:
         puppet:
-          - label: 'Puppet 7.x'
-            puppet_version: '~> 7.21.0'
+          - label: 'Puppet 7.x [SIMP 6.6/PE 2021.7]'
+            puppet_version: '~> 7.0'
             ruby_version: '2.7'
+            experimental: false
           - label: 'Puppet 8.x'
             puppet_version: '~> 8.0'
-            ruby_version: '3.2'
+            ruby_version: 3.1
+            experimental: true
     env:
-      PUPPET_VERSION: '${{matrix.puppet.puppet_version}}'
+      PUPPET_VERSION: ${{matrix.puppet.puppet_version}}
     steps:
       - uses: actions/checkout@v3
       - name: 'Install Ruby ${{matrix.puppet.ruby_version}}'
@@ -126,6 +128,7 @@ jobs:
           bundler-cache: true
       - run: 'command -v rpm || if command -v apt-get; then sudo apt-get update; sudo apt-get install -y rpm; fi ||:'
       - run: 'bundle exec rake spec'
+        continue-on-error: ${{matrix.puppet.experimental}}
 
 #  dump_contexts:
 #    name: 'Examine Context contents'

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -340,6 +340,7 @@ pup7.pe-unit:
   <<: *pup_7_pe
   <<: *unit_tests
 
+# Commenting until Puppet 8 is released
 #pup8.x-unit:
 #  <<: *pup_8_x
 #  <<: *unit_tests

--- a/.puppet-lint.rc
+++ b/.puppet-lint.rc
@@ -9,7 +9,7 @@
 --no-class_inherits_from_params_class-check
 --no-140chars-check
 --no-trailing_comma-check
---no-empty_string_assignment-check
+--no-params-empty-string-assignment-check
 # This is here because the code can't handle lookups in parameters and SIMP
 # modules have a LOT of those
 --no-parameter_order-check

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Mon Jul 10 2023 Chris Tessmer <chris.tessmer@onyxpoint.com> - 4.4.0
+- Add RockyLinux 8 support
+
 * Wed May 10 2023 Richard Gardner <Rick@sicura.us> - 4.3.2
 - Removed support for puppet 6
 - Rolled existing tests from puppet 6 to 7, 7 to 8

--- a/Gemfile
+++ b/Gemfile
@@ -21,10 +21,9 @@ group :test do
   gem 'puppetlabs_spec_helper'
   gem 'metadata-json-lint'
   gem 'puppet-strings'
-  gem 'puppet-lint-empty_string-check',   :require => false
   gem 'puppet-lint-trailing_comma-check', :require => false
   gem 'simp-rspec-puppet-facts', ENV['SIMP_RSPEC_PUPPET_FACTS_VERSION'] || '~> 3.1'
-  gem 'simp-rake-helpers', ENV['SIMP_RAKE_HELPERS_VERSION'] || ['>= 5.19.2', '< 6']
+  gem 'simp-rake-helpers', ENV['SIMP_RAKE_HELPERS_VERSION'] || ['>= 5.12.1', '< 6']
   gem( 'pdk', ENV['PDK_VERSION'] || '~> 2.0', :require => false) if major_puppet_version > 5
   gem 'pathspec', '~> 0.2' if Gem::Requirement.create('< 2.6').satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
 end

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-xinetd",
-  "version": "4.3.2",
+  "version": "4.4.0",
   "author": "SIMP Team",
   "summary": "Manages xinetd",
   "license": "Apache-2.0",
@@ -14,7 +14,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 6.6.0 < 8.0.0"
+      "version_requirement": ">= 8.0.0 < 9.0.0"
     },
     {
       "name": "simp/simplib",
@@ -52,6 +52,12 @@
       "operatingsystem": "OracleLinux",
       "operatingsystemrelease": [
         "7",
+        "8"
+      ]
+    },
+    {
+      "operatingsystem": "Rocky",
+      "operatingsystemrelease": [
         "8"
       ]
     }


### PR DESCRIPTION
This patch adds support for RockyLinux 8

The patch enforces a standardized asset baseline using simp/puppetsync,
and may also apply other updates to ensure conformity.